### PR TITLE
Comment out continue statements in message handling

### DIFF
--- a/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
+++ b/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
@@ -1129,7 +1129,7 @@ export class BaileysStartupService extends ChannelStartupService {
 
           if (cached && !editedMessage) {
             this.logger.info(`Message duplicated ignored: ${received.key.id}`);
-            continue;
+            //continue;
           }
 
           await this.baileysCache.set(messageKey, true, 5);
@@ -1417,7 +1417,7 @@ export class BaileysStartupService extends ChannelStartupService {
 
         if (cached) {
           this.logger.info(`Message duplicated ignored [avoid deadlock]: ${updateKey}`);
-          continue;
+          //continue;
         }
 
         await this.baileysCache.set(updateKey, true, 5);


### PR DESCRIPTION
This pull request updates Docker image publishing workflows and adjusts caching durations in the WhatsApp integration service. The main changes are grouped into workflow configuration updates and cache expiration adjustments.

**Workflow configuration updates:**

* Changed the Docker image repository from `evoapicloud/evolution-api` to `matheuscampbell/evolution-api` in the following GitHub Actions workflow files:
  - `.github/workflows/publish_docker_image.yml`
  - `.github/workflows/publish_docker_image_homolog.yml`
  - `.github/workflows/publish_docker_image_latest.yml`

**Cache expiration adjustments:**

* Reduced the cache expiration time for `messageKey` and `updateKey` in `BaileysStartupService` (`src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts`) from several minutes to 5 seconds. [[1]](diffhunk://#diff-ffe5f958e4859abb1b9ed56ccdadbeb8a94cf0e1973617fb7a4079c2a6a7484cL1135-R1135) [[2]](diffhunk://#diff-ffe5f958e4859abb1b9ed56ccdadbeb8a94cf0e1973617fb7a4079c2a6a7484cL1423-R1423)